### PR TITLE
bug fix: DefaultVolume handling

### DIFF
--- a/MediaSources/Longmynd/LongmyndProperties.cs
+++ b/MediaSources/Longmynd/LongmyndProperties.cs
@@ -57,9 +57,13 @@ namespace opentuner.MediaSources.Longmynd
             if (!_settings.DefaultMuted)
             {
                 _tuner1_properties.UpdateValue("volume_slider_1", _settings.DefaultVolume.ToString());
+                _settings.DefaultVolume = (uint)preMute;        // restore as changed by update volume_slider function
+                _tuner1_properties.UpdateMuteButtonColor("media_controls_1", Color.Transparent);
             }
             else
             {
+                _tuner1_properties.UpdateValue("volume_slider_1", "0");
+                _settings.DefaultVolume = (uint)preMute;        // restore as changed by update volume_slider function
                 _tuner1_properties.UpdateMuteButtonColor("media_controls_1", Color.Tomato);
             }
 

--- a/MediaSources/Minitiouner/MinitiounerProperties.cs
+++ b/MediaSources/Minitiouner/MinitiounerProperties.cs
@@ -67,9 +67,13 @@ namespace opentuner.MediaSources.Minitiouner
                 if (!_settings.DefaultMuted[1])
                 {
                     _tuner2_properties.UpdateValue("volume_slider_2", _settings.DefaultVolume[1].ToString());
+                    _settings.DefaultVolume[1] = (uint)preMute[1];  // restore as changed by update volume_slider function
+                    _tuner2_properties.UpdateMuteButtonColor("media_controls_2", Color.Transparent);
                 }
                 else
                 {
+                    _tuner2_properties.UpdateValue("volume_slider_2", "0");
+                    _settings.DefaultVolume[1] = (uint)preMute[1];  // restore as changed by update volume_slider function
                     _tuner2_properties.UpdateMuteButtonColor("media_controls_2", Color.Tomato);
                 }
             }
@@ -81,9 +85,13 @@ namespace opentuner.MediaSources.Minitiouner
             if (!_settings.DefaultMuted[0])
             {
                 _tuner1_properties.UpdateValue("volume_slider_1", _settings.DefaultVolume[0].ToString());
+                _settings.DefaultVolume[0] = (uint)preMute[0];  // restore as changed by update volume_slider function
+                _tuner1_properties.UpdateMuteButtonColor("media_controls_1", Color.Tomato);
             }
             else
             {
+                _tuner1_properties.UpdateMuteButtonColor("media_controls_1", Color.Tomato);
+                _settings.DefaultVolume[0] = (uint)preMute[0];  // restore as changed by update volume_slider function
                 _tuner1_properties.UpdateMuteButtonColor("media_controls_1", Color.Tomato);
             }
 

--- a/MediaSources/Winterhill/WinterhillProperties.cs
+++ b/MediaSources/Winterhill/WinterhillProperties.cs
@@ -76,9 +76,13 @@ namespace opentuner.MediaSources.Winterhill
                 if (!_settings.DefaultMuted[c])
                 {
                     _tuner_properties[c].UpdateValue("volume_slider_" + c.ToString(), _settings.DefaultVolume[c].ToString());
+                    _settings.DefaultVolume[c] = (uint)preMute[c];  // restore as changed by update volume_slider function
+                    _tuner_properties[c].UpdateMuteButtonColor("media_controls_" + c.ToString(), Color.Transparent);
                 }
                 else
                 {
+                    _tuner_properties[c].UpdateValue("volume_slider_" + c.ToString(), "0");
+                    _settings.DefaultVolume[c] = (uint)preMute[c];  // restore as changed by update volume_slider function
                     _tuner_properties[c].UpdateMuteButtonColor("media_controls_" + c.ToString(), Color.Tomato);
                 }
             }


### PR DESCRIPTION
The Default Volume is changed by setting the slider to 0 volume. This is not intended and a bug.
After changing the Volume slider restore DefaultVolume with the preMute value.