### PR TITLE
Update WinterhillProperties.cs

### DIFF
--- a/MediaSources/Winterhill/WinterhillProperties.cs
+++ b/MediaSources/Winterhill/WinterhillProperties.cs
@@ -678,7 +678,7 @@ namespace opentuner.MediaSources.Winterhill
             data.Add("dbMargin", last_dbm[device]);
             data.Add("Mer", last_mer[device]);
             data.Add("SR", _current_sr[device].ToString());
-            data.Add("Frequency", ((float)(_current_frequency[device] + _settings.Offset[device])/1000.0f).ToString("F", nfi));
+            data.Add("Frequency", ((float)(_current_frequency[device] + _current_offset[device])/1000.0f).ToString("F", nfi));
 
             return data;
         }


### PR DESCRIPTION
Fixed compile error: Use new variable "_current_offset" instead of old "_settings.Offset" in function "GetSignalData"